### PR TITLE
Enable use of render method

### DIFF
--- a/gridworld/env.py
+++ b/gridworld/env.py
@@ -20,9 +20,7 @@ class String(Space):
         return isinstance(obj, str)
 
 
-class Wrapper(gymWrapper):
-    def __getattr__(self, name):
-        return getattr(self.env, name)
+
 
 
 class GridWorld(Env):
@@ -130,7 +128,7 @@ class GridWorld(Env):
             self.reset()
             self.world.deinit()
             self.renderer = Renderer(self.world, self.agent,
-                                     width=self.render_size[0] // div, height=self.render_size[0] // div,
+                                     width=self.render_size[0] // div, height=self.render_size[1] // div,
                                      caption='Pyglet', resizable=False)
             setup()
             self.do_render = True
@@ -292,6 +290,16 @@ class GridWorld(Env):
             obs['pov'] = self.observation_space['pov'].sample()
         return obs, reward, done, {}
 
+
+class Wrapper(gymWrapper):
+    def __getattr__(self, name):
+        return getattr(self.env, name)
+    
+    def render(self, mode, **kwargs):
+        if isinstance(self.env, GridWorld):
+            return self.env.render()
+        else:
+            return self.env.render(mode, **kwargs)
 
 class SizeReward(Wrapper):
   def __init__(self, env):

--- a/gridworld/env.py
+++ b/gridworld/env.py
@@ -295,7 +295,7 @@ class Wrapper(gymWrapper):
     def __getattr__(self, name):
         return getattr(self.env, name)
     
-    def render(self, mode, **kwargs):
+    def render(self, mode="human", **kwargs):
         if isinstance(self.env, GridWorld):
             return self.env.render()
         else:


### PR DESCRIPTION
Currently the render method, when called, raises an error; `TypeError: render() takes 1 positional argument but 2 were given`

This is because the base `GridWorld` environment does not expect any argument in its render method while gym wrappers have the `mode` argument by default.

This fix updates the `render` of gym wrappers to call `self.env.render()` if the wrapped environment is `GridWorld`  and `self.env.render(mode, **kwargs)` otherwise.

Also, a bug in the render_size is corrected.