### PR TITLE
Add information about block placement to Task object when parsing tapes.

### DIFF
--- a/gridworld/data/adapter/parse.py
+++ b/gridworld/data/adapter/parse.py
@@ -13,8 +13,66 @@ from .common import DEFAULT_POS, VWEvent, \
     AIR_TYPE, VOXELWORLD_GROUND_LEVEL, NORTH_YAW, GameSession
 import numpy as np
 
-from ..iglu_dataset import IGLUDataset, SingleTurnIGLUDataset, fix_xyz, fix_log
+from ..iglu_dataset import IGLUDataset, SingleTurnIGLUDataset
 from ...utils import BUILD_ZONE_SIZE
+
+
+
+def fix_xyz(x, y, z):
+    XMAX = 11
+    YMAX = 9
+    ZMAX = 11
+    COORD_SHIFT = [5, -63, 5]
+
+    x += COORD_SHIFT[0]
+    y += COORD_SHIFT[1]
+    z += COORD_SHIFT[2]
+
+    index = z + y * ZMAX + x * YMAX * ZMAX
+    new_x = index // (YMAX * ZMAX)
+    index %= (YMAX * ZMAX)
+    new_y = index // ZMAX
+    index %= ZMAX
+    new_z = index % ZMAX
+
+    new_x -= COORD_SHIFT[0]
+    new_y -= COORD_SHIFT[1]
+    new_z -= COORD_SHIFT[2]
+
+    return new_x, new_y, new_z
+
+
+def fix_log(log_string):
+    """
+    log_string: str
+        log_string should be a string of the full log.
+        It should be multiple lines, each corresponded to a timestamp,
+        and should be separated by newline character.
+    """
+
+    lines = []
+
+    for line in log_string.splitlines():
+
+        if "block_change" in line:
+            line_splits = line.split(" ", 2)
+            try:
+                info = eval(line_splits[2])
+            except:
+                lines.append(line)
+                continue
+            x, y, z = info[0], info[1], info[2]
+            new_x, new_y, new_z = fix_xyz(x, y, z)
+            new_info = (new_x, new_y, new_z, info[3], info[4])
+            line_splits[2] = str(new_info)
+            fixed_line = " ".join(line_splits)
+            # logging.info(f"Fixed {line} to {fixed_line}")
+
+            lines.append(fixed_line)
+        else:
+            lines.append(line)
+
+    return "\n".join(lines)
 
 
 class ActionsParser:
@@ -135,7 +193,7 @@ class ActionsParser:
             block, prev = self.world.hit_test(self.agent.position, vector, max_distance=10)
             bid, x, y, z = list(map(int, args[:4]))
             y -= VOXELWORLD_GROUND_LEVEL + 1
-            bid = self.block_map[bid]
+            bid = self.block_map.get(bid, 3)
             new_block = (x, y, z, bid)
             gridUpdate = [new_block]
         else:
@@ -178,7 +236,7 @@ class ActionsParser:
         start_position = (x, y, z, pitch, yaw)
 
         initial_blocks = [
-            (x, y - VOXELWORLD_GROUND_LEVEL - 1, z, self.block_map[bid]
+            (x, y - VOXELWORLD_GROUND_LEVEL - 1, z, self.block_map[bid])
             for (x, y, z, bid) in data['worldEndingState']['blocks']
         ]
         return start_position, initial_blocks

--- a/gridworld/tasks/task.py
+++ b/gridworld/tasks/task.py
@@ -6,7 +6,7 @@ BUILD_ZONE_SIZE = 9, 11, 11
 
 
 class Task:
-    def __init__(self, chat, target_grid, last_instruction=None, starting_grid=None, full_grid=None, invariant=True):
+    def __init__(self, chat, target_grid, last_instruction=None, starting_grid=None, full_grid=None, invariant=True, block_changes=None):
         """Creates a new Task represented with the past dialog and grid,
         the new instruction and target grid after completing the instruction.
 
@@ -30,6 +30,7 @@ class Task:
         self.chat = chat
         self.starting_grid = starting_grid
         self.last_instruction = last_instruction
+        self.block_changes = block_changes
         self.full_grid = full_grid
         self.admissible = [[] for _ in range(4)]
         self.target_size = (target_grid != 0).sum().item()
@@ -208,11 +209,12 @@ class Tasks:
 class Subtasks(Tasks):
     """ Subtasks object represents a staged task where subtasks represent separate segments
     """
-    def __init__(self, dialog, structure_seq, invariant=False, progressive=True) -> None:
+    def __init__(self, dialog, structure_seq, block_changes, invariant=False, progressive=True) -> None:
         self.dialog = dialog
         self.invariant = invariant
         self.progressive = progressive
         self.structure_seq = structure_seq
+        self.block_changes = block_changes
         self.next = None
         self.full = False
         self.task_start = 0
@@ -279,7 +281,8 @@ class Subtasks(Tasks):
             dialog, target_grid=self.to_dense(target_grid),
             starting_grid=self.to_sparse(initial_blocks),
             full_grid=self.full_structure,
-            last_instruction='\n'.join(self.dialog[tid])
+            last_instruction='\n'.join(self.dialog[tid]),
+            block_changes=self.block_changes[tid] if hasattr(self, "block_changes") else [],
         )
         # To properly init max_int and prev_grid_size fields
         task.reset()

--- a/tests/test_block_placements.py
+++ b/tests/test_block_placements.py
@@ -1,0 +1,43 @@
+import numpy as np
+from gridworld.data import IGLUDataset
+from gridworld.tasks import Tasks
+
+from tqdm import tqdm
+
+dataset_rc2 = IGLUDataset(dataset_version="v0.1.0-rc2", force_parsing=False)
+dataset_rc3 = IGLUDataset(dataset_version="v0.1.0-rc3", force_parsing=True)
+
+print("Test: Verifying data in v0.1.0-rc2 and v0.1.0-rc3 is the same.")
+task_ids = list(dataset_rc3.tasks.keys())
+for key in tqdm(task_ids, desc="Structures", leave=False):
+    assert len(dataset_rc2.tasks[key]) == len(dataset_rc3.tasks[key])
+
+    for j in tqdm(range(len(dataset_rc3.tasks[key])), leave=False, desc="Tasks"):
+        assert len(dataset_rc2.tasks[key][j]) >= len(dataset_rc3.tasks[key][j])
+
+        tasks_new = list(dataset_rc3.tasks[key][j])
+        tasks_orig = list(dataset_rc2.tasks[key][j])
+        for k in range(len(tasks_new)):
+            assert len(tasks_new[k]) == len(tasks_orig[k])
+            assert tasks_orig[k].last_instruction == tasks_new[k].last_instruction
+            assert tasks_orig[k].starting_grid == tasks_new[k].starting_grid
+            assert np.all(tasks_orig[k].target_grid == tasks_new[k].target_grid)
+
+print("Success!")
+
+print("Test: Replaying block changes to build the target structure.")
+task_ids = list(dataset_rc3.tasks.keys())
+for key in tqdm(task_ids, desc="Structures"):
+    for j in tqdm(range(len(dataset_rc3.tasks[key])), leave=False, desc="Tasks"):
+        tasks = list(dataset_rc3.tasks[key][j])
+        for k in range(len(tasks)):
+            task = tasks[k]
+            grid = {tuple((x,y,z)): bid for x,y,z,bid in task.starting_grid}
+
+            for x, y, z, bid in task.block_changes:
+                assert grid.get(tuple((x, y, z)), 0) != bid, "Already set! Redundant block changes?"
+                grid[tuple((x, y, z))] = bid
+
+            sorted(grid) == sorted(Tasks.to_sparse(task.target_grid.transpose((1,0,2))))
+
+print("Success!")


### PR DESCRIPTION
This PR adds a new member variable to `Task` objects, `block_changes`. This variable provide the block change (in the right order) to reproduce the `target.grid` structure from the `starting_grid`.

Some changes were needed in the code for parsing the datasets.
- [x] Multiturn dataset
- [ ] Singleturn dataset